### PR TITLE
docs(`README`): direct users to the main repository for creating issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ guest based on [Alpine Linux].
 
 *This is a work-in-progress experimental software project without any
 guarantees or warranties.  It is shared in the hope that is going to
-be useful and inspiring for others.*
+be useful and inspiring for others.  Please report issues at the
+[FreeBSD Wifibox] repository directly.*
 
 ## Prerequisites
 


### PR DESCRIPTION
It is much easier to keep track of the existing issue if they are handled in a single repository.  In parallel to disabling the issue submission option, add a sentence on guidance for the users.