### PR TITLE
fix(`Makefile`): try unmounting `linprocfs` for non-root users

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,11 +106,9 @@ $(GUESTDIR)/.done:
 	$(ENV) LD_LIBRARY_PATH=$(BOOTSTRAPDIR)/lib \
 		$(_BUSYBOX) \
 		depmod -A -b $(GUESTDIR) $$($(LS) $(GUESTDIR)/lib/modules)
-	# try umounting `linprocfs` if that was mounted (on FreeBSD 13
-	# or later), usually happens for `root`
-.if $(UID) == 0
+	# try unmounting `linprocfs` if that was mounted (on FreeBSD 13
+	# or later)
 	$(UMOUNT) $(GUESTDIR)/proc || $(TRUE)
-.endif
 	# install extra files manually
 .if exists($(PWD)/guest)
 	$(CP) -R $(PWD)/guest/ $(GUESTDIR)


### PR DESCRIPTION
During the build process, the `proc` directory under the image root is left over on FreeBSD 13 (and later) even for non-root users.  Lift the restriction on the root-user case and make an attempt to unmount this file system in every case.