### PR TITLE
chore(`docs`): adjust the manual page directory for installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ ETC_SRCS?=$(PWD)/etc/wpa_supplicant
 ROOT=$(PREFIX)/share/wifibox
 SHAREDIR=$(DESTDIR)$(ROOT)
 ETCDIR=$(DESTDIR)$(PREFIX)/etc/wifibox
-MANDIR=$(DESTDIR)$(PREFIX)/man
+MANDIR=$(DESTDIR)$(PREFIX)/share/man
 RUNDIR=$(DESTDIR)/var/run/wifibox
 
 WORKDIR?=$(PWD)/work


### PR DESCRIPTION
The FreeBSD Ports Collection [is moving towards](https://cgit.freebsd.org/ports/commit/?id=003a571d1d6585196545295efc181514f171c4c4) making the `share/man` as the default location for manual pages under the `LOCALBASE` .  Reflect the same here as well.

Partially fixes [wifibox#89](https://github.com/pgj/freebsd-wifibox/issues/89)
