### PR TITLE
fix(`etc/wpa_supplicant`): revert restricting `udhcpd` for a single IP address

### DIFF
--- a/etc/wpa_supplicant/appliance/udhcpd.conf.sample
+++ b/etc/wpa_supplicant/appliance/udhcpd.conf.sample
@@ -4,17 +4,19 @@
 # The value of `interface` should match with the one defined in the
 # interfaces.conf file: `interface` should be exactly the same,
 # `router` should correspond to `address` and `subnet` is the
-# `netmask`.  According to these settings below, a single IP address
-# (10.0.0.2) is handed out, since only one is expected.  In the `opt
-# dns` line, the `%%DNS%%` variable would be replaced with the IP
-# addresses of the DNS servers as provided by the wireless network
-# (wifibox extension).
+# `netmask`.  According to these settings below, IP addresses are
+# handed out for the 10.0.0.0/24 network.  Even though there is a
+# single client expected, on quick restarts, the previously allocated
+# address might not be released, so there should be some room left for
+# such overlaps.  In the `opt dns` line, the `%%DNS%%` variable would
+# be replaced with the IP addresses of the DNS servers as provided by
+# the wireless network (wifibox extension).
 #
 # Change these only if this is not suitable.
 
 start		10.0.0.2
-end		10.0.0.2
-max_leases	1
+end		10.0.0.254
+max_leases	64
 interface	eth0
 opt	subnet	255.255.255.0
 opt	router	10.0.0.1


### PR DESCRIPTION
Even if there is a single client, it may happen that the previous lease has not yet expired and on the next occasion, the same IP address is not available.  It looks awkward for now, but it is better to let addresses allocated from a pool instead to avoid this problem.