### PR TITLE
fix: remove APK metadata after package installs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,8 @@ $(GUESTDIR)/.done:
 			--no-scripts \
 			--no-chown \
 			$(PACKAGES)
+	# remove APK metadata
+	$(RM) -rf $(GUESTDIR)/lib/apk
 	# rebuild module dependency data
 	$(ENV) LD_LIBRARY_PATH=$(BOOTSTRAPDIR)/lib \
 		$(_BUSYBOX) \


### PR DESCRIPTION
The `apk` tool produces some metadata files on installing the packages.  These files will not be used later so they would only increase the size of the produced disk image.