### PR TITLE
fix(`rtw89`): roll back to snapshot of `20240106` due to regression in upstream

### DIFF
--- a/aports/rtw89-edge/APKBUILD
+++ b/aports/rtw89-edge/APKBUILD
@@ -1,9 +1,9 @@
 # Maintainer: Gabor Pali <pali.gabor@gmail.com>
 
 pkgname='rtw89-edge'
-pkgver=20240310
+pkgver=20240106
 pkgrel=06080010100
-_gitrev='48680abfeb843330d385384bd8edde259a241147'
+_gitrev='6dc9441698a7f2f79ff8f74c6ea3704c0c8feb61'
 pkgdesc='Driver for Realtek 8852AE, an 802.11ax device (edge)'
 arch="x86_64"
 url='https://github.com/lwfinger/rtw89'
@@ -28,5 +28,5 @@ package() {
 }
 
 sha512sums="
-3c92a0502d398ccb262fa92231fe43264eb7de3da9a57a74e265cf8422134bf5fee3b4de2cd1aa75946b4796f1b025e1b232d0f8710b04f7f3cbd3e0a9ddd9d8  48680abfeb843330d385384bd8edde259a241147.zip
+abc7ae94bac8a4ddb86d623c95f8ff6cd94ab88c4a462be471e8af0d29aa45d08ec0bc1f7c56d54e42f77201a0976dd39e8c0d06754d850fdf117abd1b3ce94d  6dc9441698a7f2f79ff8f74c6ea3704c0c8feb61.zip
 "

--- a/aports/rtw89/APKBUILD
+++ b/aports/rtw89/APKBUILD
@@ -1,9 +1,9 @@
 # Maintainer: Gabor Pali <pali.gabor@gmail.com>
 
 pkgname='rtw89'
-pkgver=20240310
+pkgver=20240106
 pkgrel=06060220100
-_gitrev='48680abfeb843330d385384bd8edde259a241147'
+_gitrev='6dc9441698a7f2f79ff8f74c6ea3704c0c8feb61'
 pkgdesc='Driver for Realtek 8852AE, an 802.11ax device'
 arch="x86_64"
 url='https://github.com/lwfinger/rtw89'
@@ -28,5 +28,5 @@ package() {
 }
 
 sha512sums="
-3c92a0502d398ccb262fa92231fe43264eb7de3da9a57a74e265cf8422134bf5fee3b4de2cd1aa75946b4796f1b025e1b232d0f8710b04f7f3cbd3e0a9ddd9d8  48680abfeb843330d385384bd8edde259a241147.zip
+abc7ae94bac8a4ddb86d623c95f8ff6cd94ab88c4a462be471e8af0d29aa45d08ec0bc1f7c56d54e42f77201a0976dd39e8c0d06754d850fdf117abd1b3ce94d  6dc9441698a7f2f79ff8f74c6ea3704c0c8feb61.zip
 "


### PR DESCRIPTION
The `20240310` snapshot of `rtw89` does not work for 8852BE cards. Similar problems were reported upstream for older Ubuntu versions and as a fix it was suggested to move back to an older version.

Although the kernel that Wifibox/Alpine uses is much more recent than one could find in Ubuntu 20.04, the same resolution still works.  Based on that, chances are likely that the scope of the regression in the `rtw89` driver is wider than assumed.

The proposed version was verified to be working, so go back to and stick to it until the issue is resolved in upstream.

References:
- https://github.com/lwfinger/rtw89/issues/320
- https://github.com/lwfinger/rtw89/issues/323
- https://github.com/pgj/freebsd-wifibox/issues/96