### PR TITLE
fix(`man`): references to Linux kernel versions

### DIFF
--- a/man/wifibox-alpine.5
+++ b/man/wifibox-alpine.5
@@ -375,11 +375,11 @@ Further components of the guest that are not directly configurable or
 visible to the outside:
 .Bl -bullet
 .It
-Version 6.1 (LTS) of the Linux kernel and its wireless drivers are
+Version 6.6 (LTS) of the Linux kernel and its wireless drivers are
 used to communicate with exposed hardware.  It does not always work
 with the latest ones, see the section on supported hardware for the
 exact details.  Alternatively, it is possible to configure the image
-to have Linux 6.5 (stable) which could be suitable for testing
+to have Linux 6.8 (stable) which could be suitable for testing
 experimental features and drivers.
 .It
 .Sy busybox


### PR DESCRIPTION
During the recent upgrades, versions for each of the Linux kernels in use has not been updated, which results in stale information.