### PR TITLE
Ensure that dhcpcd run-hooks can manage multiple nameservers from the resolv.conf file.

### DIFF
--- a/aports/dhcpcd/99-radvd.conf
+++ b/aports/dhcpcd/99-radvd.conf
@@ -10,7 +10,7 @@ if $if_configured; then
 
   # Filter resolv.conf to get the IPv6 name servers
   # only.
-  dns=$(grep -F nameserver $RESOLV_CONF | cut -c 12- | grep -E "^[0-9]*:")
+  dns=$(grep -F nameserver $RESOLV_CONF | cut -c 12- | grep -E "^[0-9]*:" | tr '\n' ' ')
 
   cat $RADVD_CONF_TEMPLATE \
     | sed "s!%%DNS%%!$dns!" \

--- a/aports/dhcpcd/99-udhcpd.conf
+++ b/aports/dhcpcd/99-udhcpd.conf
@@ -10,7 +10,7 @@ if $if_configured; then
 
   # Filter resolv.conf to get the IPv4 name servers
   # only.
-  dns=$(grep -F nameserver $RESOLV_CONF | cut -c 12- | grep -E "^[0-9\.]*$")
+  dns=$(grep -F nameserver $RESOLV_CONF | cut -c 12- | grep -E "^[0-9\.]*$" | tr '\n' ' ')
 
   cat $UDHCPD_CONF_TEMPLATE \
     | sed "s!%%DNS%%!$dns!" \


### PR DESCRIPTION
Previously, an error would occur in both the radvd and udhcpd runtime hooks if multiple nameservers were found in /etc/resolv.conf:
```
$ dns=$(grep -F nameserver $RESOLV_CONF | cut -c 12- | grep -E "^[0-9\.]*$") $ echo "$dns"
80.254.79.7
80.254.79.93
$ cat /etc/udhcpd.conf | sed "s!%%DNS%%!$dns!"
sed: unmatched '!'
```