### PR TITLE
chore(`LICENSE`): bump copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 2-Clause License
 
-Copyright (c) 2022-23, PÁLI Gábor János
+Copyright (c) 2022-24, PÁLI Gábor János
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Apparently the copyright year in the license file did not get updated at the previous release.  So do it now.