### PR TITLE
udhcpd: Add %%DOMAIN%% variable to match %%DNS%%

### DIFF
--- a/aports/dhcpcd/99-udhcpd.conf
+++ b/aports/dhcpcd/99-udhcpd.conf
@@ -11,9 +11,11 @@ if $if_configured; then
   # Filter resolv.conf to get the IPv4 name servers
   # only.
   dns=$(grep -F nameserver $RESOLV_CONF | cut -c 12- | grep -E "^[0-9\.]*$" | tr '\n' ' ')
+  domain=$(grep -F domain $RESOLV_CONF | cut -c 8-)
 
   cat $UDHCPD_CONF_TEMPLATE \
     | sed "s!%%DNS%%!$dns!" \
+    | sed "s!%%DOMAIN%%!$domain!" \
     > $UDHCPD_CONF
   chmod a+r "$UDHCPD_CONF"
   service udhcpd --ifstarted restart


### PR DESCRIPTION
Hi,

I didn't see an issue tracker, just wanted to call attention to an issue.  I'm running with this patch.  I am not sure if this is your preferred way to address this, if at all.

I noticed that the DHCP option for "domain" is not propagated from guest to host.  I like to rely on that to alter the search behavior if you don't specify a fully qualified hostname.  So I added this %%DOMAIN%% variable, which I plumb to udhcpd.conf (``opt domain %%DOMAIN%%``).  I did not touch the documentation or examples in this branch.

Another thought  I had to fix this was to allow the wifibox end user to write their own ``dhcpd.enter-hook``, ``dhcpd.exit-hook``, then they could decide for themselves what DHCP options they're interested in and how to handle them, but I didn't look too deeply into how the wifibox pieces fit together to see how to do that.

Just passing along in case it is something that interests you.  Thanks.