### PR TITLE
chore(`rtw89`): unbreak build and update to `20250808` snapshot

### DIFF
--- a/aports/rtw89-edge/APKBUILD
+++ b/aports/rtw89-edge/APKBUILD
@@ -1,22 +1,25 @@
 # Maintainer: Gabor Pali <pali.gabor@gmail.com>
 
 pkgname='rtw89-edge'
-pkgver=20250317
+pkgver=20250808
 pkgrel=06130070000
-_gitrev='e9b4224872ebc1e2920267e33e5eb079f33e48c8'
-pkgdesc='Driver for Realtek 8852AE, an 802.11ax device (edge)'
+_gitrev='2b491dca7e3dda64eeada28079ee4c02b78f48ac'
+pkgdesc='Linux drivers for Realtek Wi-Fi 6/6E and Wi-Fi 7 adapters and cards (edge)'
 arch="x86_64"
-url='https://github.com/a5a5aa555oo/rtw89'
+url='https://github.com/morrownr/rtw89'
 license="GPL-2.0"
-makedepends="linux-edge-dev xz bash"
+makedepends="linux-edge-dev xz"
 depends="linux-edge"
 install=
 options="!check !strip"
-source="https://github.com/a5a5aa555oo/rtw89/archive/${_gitrev}.zip"
+source="Makefile.patch
+	debug.c.patch
+	https://github.com/morrownr/rtw89/archive/${_gitrev}.zip"
 
 _kver=$(cd /usr/src/ && find . -mindepth 1 -maxdepth 1 -type d -name '*-edge' | sed 's!./linux-headers-!!')
 _kbase="/lib/modules/${_kver}"
 _srcdir="$srcdir/rtw89-$_gitrev"
+builddir="$_srcdir"
 
 build() {
   make -C "$_srcdir" KVER="$_kver"
@@ -28,5 +31,7 @@ package() {
 }
 
 sha512sums="
-82b95b0d12514559432392b83b2b4005e7a9098a0529a55fac9956fe5bfc3c0b4df9e4b989f7bc4b8c64812ab9637ca16681bcf30b9d5c9212a36054aab09c9d  e9b4224872ebc1e2920267e33e5eb079f33e48c8.zip
+4ab14f571f3358519e63cdf3924ec610bf4ff3a40bb284d4ce587a888f1407cb922c1a32ecab3a6d2d56577a9e72d9e2e07bf4f822b9ada59f8bcc00cb2103c1  Makefile.patch
+dde8f7102ccaf8060e0c29832590a026230cb4a0d6c8eac196afdd856d30e86908f3a6f6423fad2197b952792265e1c2c3d50aa3e8c96bf6b109c5240e33e12b  debug.c.patch
+946a42666d9e61d3956c5c84155eab0d0ac25d9a74c17d664ff1d8fc05c0c30fe1793aa7e532e7fa641ad0f15b80be7d49a6e2df5239cc42cdfbfedeccc1848f  2b491dca7e3dda64eeada28079ee4c02b78f48ac.zip
 "

--- a/aports/rtw89-edge/Makefile.patch
+++ b/aports/rtw89-edge/Makefile.patch
@@ -1,0 +1,47 @@
+--- a/Makefile
++++ b/Makefile
+@@ -34,9 +34,6 @@
+ obj-m += rtw89_8851be_git.o
+ rtw89_8851be_git-objs := rtw8851be.o
+ 
+-obj-m += rtw89_8851bu_git.o
+-rtw89_8851bu_git-objs := rtw8851bu.o
+-
+ obj-m += rtw89_8852a_git.o
+ rtw89_8852a_git-objs := rtw8852a.o \
+ 			rtw8852a_table.o \
+@@ -58,9 +55,6 @@
+ obj-m += rtw89_8852be_git.o
+ rtw89_8852be_git-objs := rtw8852be.o
+ 
+-obj-m += rtw89_8852bu_git.o
+-rtw89_8852bu_git-objs := rtw8852bu.o
+-
+ obj-m += rtw89_8852bt_git.o
+ rtw89_8852bt_git-objs := rtw8852bt.o \
+ 			 rtw8852bt_rfk.o \
+@@ -78,9 +72,6 @@
+ obj-m += rtw89_8852ce_git.o
+ rtw89_8852ce_git-objs := rtw8852ce.o
+ 
+-obj-m += rtw89_8852cu_git.o
+-rtw89_8852cu_git-objs := rtw8852cu.o
+-
+ obj-m += rtw89_8922a_git.o
+ rtw89_8922a_git-objs := rtw8922a.o \
+ 			rtw8922a_rfk.o
+@@ -88,14 +79,8 @@
+ obj-m += rtw89_8922ae_git.o
+ rtw89_8922ae_git-objs := rtw8922ae.o
+ 
+-obj-m += rtw89_8922au_git.o
+-rtw89_8922au_git-objs := rtw8922au.o
+-
+ obj-m += rtw89_pci_git.o
+ rtw89_pci_git-y := pci.o pci_be.o
+-
+-obj-m += rtw89_usb_git.o
+-rtw89_usb_git-y := usb.o
+ 
+ ccflags-y += -Wno-compare-distinct-pointer-types
+ ccflags-y += -DCONFIG_RTW89_DEBUGMSG -DCONFIG_RTW89_DEBUGFS

--- a/aports/rtw89-edge/debug.c.patch
+++ b/aports/rtw89-edge/debug.c.patch
@@ -1,0 +1,11 @@
+--- a/debug.c
++++ b/debug.c
+@@ -233,7 +233,7 @@
+ 	return debugfs_priv->cb_write(rtwdev, debugfs_priv, buf, count);
+ }
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0) && defined(CONFIG_DEBUG_FS)
+ static const struct debugfs_short_fops file_ops_single_r = {
+ 	.read = rtw89_debugfs_file_read,
+ 	.llseek = generic_file_llseek,

--- a/aports/rtw89/APKBUILD
+++ b/aports/rtw89/APKBUILD
@@ -1,22 +1,24 @@
 # Maintainer: Gabor Pali <pali.gabor@gmail.com>
 
 pkgname='rtw89'
-pkgver=20250317
+pkgver=20250808
 pkgrel=06120190000
-_gitrev='e9b4224872ebc1e2920267e33e5eb079f33e48c8'
-pkgdesc='Driver for Realtek 8852AE, an 802.11ax device'
+_gitrev='2b491dca7e3dda64eeada28079ee4c02b78f48ac'
+pkgdesc='Linux drivers for Realtek Wi-Fi 6/6E and Wi-Fi 7 adapters and cards'
 arch="x86_64"
-url='https://github.com/a5a5aa555oo/rtw89'
+url='https://github.com/morrownr/rtw89'
 license="GPL-2.0"
 makedepends="linux-lts-dev xz"
 depends="linux-lts"
 install=
 options="!check !strip"
-source="https://github.com/a5a5aa555oo/rtw89/archive/${_gitrev}.zip"
+source="Makefile.patch
+	https://github.com/morrownr/rtw89/archive/${_gitrev}.zip"
 
 _kver=$(cd /usr/src/ && find . -mindepth 1 -maxdepth 1 -type d -name '*-lts' | sed 's!./linux-headers-!!')
 _kbase="/lib/modules/${_kver}"
 _srcdir="$srcdir/rtw89-$_gitrev"
+builddir="$_srcdir"
 
 build() {
   make -C "$_srcdir" KVER="$_kver"
@@ -28,5 +30,6 @@ package() {
 }
 
 sha512sums="
-82b95b0d12514559432392b83b2b4005e7a9098a0529a55fac9956fe5bfc3c0b4df9e4b989f7bc4b8c64812ab9637ca16681bcf30b9d5c9212a36054aab09c9d  e9b4224872ebc1e2920267e33e5eb079f33e48c8.zip
+4ab14f571f3358519e63cdf3924ec610bf4ff3a40bb284d4ce587a888f1407cb922c1a32ecab3a6d2d56577a9e72d9e2e07bf4f822b9ada59f8bcc00cb2103c1  Makefile.patch
+946a42666d9e61d3956c5c84155eab0d0ac25d9a74c17d664ff1d8fc05c0c30fe1793aa7e532e7fa641ad0f15b80be7d49a6e2df5239cc42cdfbfedeccc1848f  2b491dca7e3dda64eeada28079ee4c02b78f48ac.zip
 "

--- a/aports/rtw89/Makefile.patch
+++ b/aports/rtw89/Makefile.patch
@@ -1,0 +1,47 @@
+--- a/Makefile
++++ b/Makefile
+@@ -34,9 +34,6 @@
+ obj-m += rtw89_8851be_git.o
+ rtw89_8851be_git-objs := rtw8851be.o
+ 
+-obj-m += rtw89_8851bu_git.o
+-rtw89_8851bu_git-objs := rtw8851bu.o
+-
+ obj-m += rtw89_8852a_git.o
+ rtw89_8852a_git-objs := rtw8852a.o \
+ 			rtw8852a_table.o \
+@@ -58,9 +55,6 @@
+ obj-m += rtw89_8852be_git.o
+ rtw89_8852be_git-objs := rtw8852be.o
+ 
+-obj-m += rtw89_8852bu_git.o
+-rtw89_8852bu_git-objs := rtw8852bu.o
+-
+ obj-m += rtw89_8852bt_git.o
+ rtw89_8852bt_git-objs := rtw8852bt.o \
+ 			 rtw8852bt_rfk.o \
+@@ -78,9 +72,6 @@
+ obj-m += rtw89_8852ce_git.o
+ rtw89_8852ce_git-objs := rtw8852ce.o
+ 
+-obj-m += rtw89_8852cu_git.o
+-rtw89_8852cu_git-objs := rtw8852cu.o
+-
+ obj-m += rtw89_8922a_git.o
+ rtw89_8922a_git-objs := rtw8922a.o \
+ 			rtw8922a_rfk.o
+@@ -88,14 +79,8 @@
+ obj-m += rtw89_8922ae_git.o
+ rtw89_8922ae_git-objs := rtw8922ae.o
+ 
+-obj-m += rtw89_8922au_git.o
+-rtw89_8922au_git-objs := rtw8922au.o
+-
+ obj-m += rtw89_pci_git.o
+ rtw89_pci_git-y := pci.o pci_be.o
+-
+-obj-m += rtw89_usb_git.o
+-rtw89_usb_git-y := usb.o
+ 
+ ccflags-y += -Wno-compare-distinct-pointer-types
+ ccflags-y += -DCONFIG_RTW89_DEBUGMSG -DCONFIG_RTW89_DEBUGFS


### PR DESCRIPTION
The previous [GitHub repository](https://github.com/a5a5aa555oo/rtw89) from where the `rtw89` drivers were consumed has had its history rewritten and the old commit reference does not work any more.  After studying the related changes, it turned out that the support there has become limited to 6.6 only.

For a more recent version of the driver, [another repository](https://github.com/morrownr/rtw89) was suggested, so switch over to that and unbreak the build.  As a consequence, the driver is now updated to a more recent snapshot.
